### PR TITLE
get_robots_txt_content with Accept: text/plain

### DIFF
--- a/src/lib/helper.rb
+++ b/src/lib/helper.rb
@@ -204,7 +204,7 @@ module Helper
 
   def self.get_robots_txt_content(base_url:, private_key_content: nil)
     robots_txt_url = URI.join(base_url, '/robots.txt').to_s
-    puts "Fetching robots.txt from #{robots_txt_url}..."
+    puts "Fetching robots.txt from #{robots_txt_url}"
     authority = URI.parse(robots_txt_url).authority
     headers = get_headers(authority, private_key_content).merge("Accept" => "text/plain, */*")
     response = URI.open(robots_txt_url, headers)

--- a/src/lib/helper.rb
+++ b/src/lib/helper.rb
@@ -202,11 +202,17 @@ module Helper
     graph.query([nil, RDF.type, nil]).map(&:object).uniq
   end
 
-  def self.get_robots_txt_content(base_url: , page_fetcher: )
+  def self.get_robots_txt_content(base_url:, private_key_content: nil)
     robots_txt_url = URI.join(base_url, '/robots.txt').to_s
     puts "Fetching robots.txt from #{robots_txt_url}..."
-    robots_txt_data, _ = page_fetcher.fetcher_with_retry(page_url: robots_txt_url)
+    authority = URI.parse(robots_txt_url).authority
+    headers = get_headers(authority, private_key_content).merge("Accept" => "text/plain, */*")
+    response = URI.open(robots_txt_url, headers)
+    robots_txt_data = response.read
     RobotsTxtParser.parse(robots_txt_data)
+  rescue StandardError => e
+    puts "Warning: Could not fetch robots.txt: #{e.message}. Allowing all paths."
+    RobotsTxtParser.parse(nil)
   end
 
   def self.get_page_type(content_type)

--- a/src/main.rb
+++ b/src/main.rb
@@ -88,7 +88,7 @@ if mode.include?('fetch')
       url: page_url,
       page_fetcher: page_fetcher,
       sparql_path: "./sparql/",
-      robots_txt_content: Helper.get_robots_txt_content(base_url: base_url, page_fetcher: page_fetcher)
+      robots_txt_content: Helper.get_robots_txt_content(base_url: base_url, private_key_content: cloudflare_private_key)
     )
     start_time = Time.now.utc.iso8601
     if metadata_content&.[]('skip_crawl') == "true"
@@ -126,7 +126,7 @@ if mode.include?('fetch')
       is_paginated: is_paginated,
       offset: offset,
       page_fetcher: page_fetcher,
-      robots_txt_content: Helper.get_robots_txt_content(base_url: base_url, page_fetcher: page_fetcher)
+      robots_txt_content: Helper.get_robots_txt_content(base_url: base_url, private_key_content: cloudflare_private_key)
     )
 
     entity_urls = url_fetcher.fetch_urls()

--- a/src/url_fetcher_service/url_fetcher.rb
+++ b/src/url_fetcher_service/url_fetcher.rb
@@ -19,7 +19,7 @@ module UrlFetcherService
         page_number = get_page_number(@is_paginated)
         loop do
           url = "#{page}#{page_number}"
-          puts "Fetching entity urls from #{url}..."
+          puts "Fetching entity urls from #{url}"
           page_data, content_type = @page_fetcher.fetcher_with_retry(page_url: url, selector: identifier)   
           if !page_data.nil? 
             @atleast_one_page_loaded = true


### PR DESCRIPTION
get_robots_txt_content now uses URI.open directly with an explicit Accept: text/plain, */* header (overriding any linkeddata patch)